### PR TITLE
Add phone number to footer

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -166,6 +166,9 @@ import { OpenPanelComponent } from '@openpanel/astro';
                         74 E Glenwood Ave Unit 5756, Smyrna, DE
                     </p>
                     <p class="sneaky">
+                        <a href="tel:+12018701491">(201) 870-1491</a>
+                    </p>
+                    <p class="sneaky">
                         Third-party project names used for illustrative purposes only.
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- Adds the organization phone number (201) 870-1491 to the website footer
- Phone number is clickable (tel: link) for mobile users
- Uses existing "sneaky" styling to match the address display

## Test plan
- [ ] Verify phone number appears in footer on all pages
- [ ] Verify phone number is clickable and initiates a call on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)